### PR TITLE
Change package.json's river.tmLanguage.json reference to alloy.tmLanguage.json, bump the version and make the changes in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.2.0-alpha.3
+
+### Changes
+
+* Changed the path for the `alloy` language grammar from `river.tmLanguage.json` to `alloy.tmLanguage.json`
+
 ## v0.2.0-alpha.2
 
 ### Changes

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "alloy",
     "displayName": "Alloy",
     "description": "Alloy configuration language support",
-    "version": "0.2.0-alpha.2",
+    "version": "0.2.0-alpha.3",
     "author": "robigan",
     "publisher": "robigan",
     "repository": {
@@ -34,7 +34,7 @@
             {
                 "language": "alloy",
                 "scopeName": "source.alloy",
-                "path": "./syntaxes/river.tmLanguage.json"
+                "path": "./syntaxes/alloy.tmLanguage.json"
             }
         ]
     }


### PR DESCRIPTION
Update the path for the `alloy` language grammar and bump the version in `package.json`, and reflect these changes in `CHANGELOG.md`.

* Change the path for the `alloy` language grammar from `./syntaxes/river.tmLanguage.json` to `./syntaxes/alloy.tmLanguage.json` in `package.json`.
* Bump the version from `0.2.0-alpha.2` to `0.2.0-alpha.3` in `package.json`.
* Add a new version entry `v0.2.0-alpha.3` in `CHANGELOG.md`.
* Mention the change of the path for the `alloy` language grammar from `river.tmLanguage.json` to `alloy.tmLanguage.json` in `CHANGELOG.md`.

